### PR TITLE
Fix Flyway migration failure for CRUD table

### DIFF
--- a/application/src/main/resources/db/migration/V1__create_crud_table.sql
+++ b/application/src/main/resources/db/migration/V1__create_crud_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE crud (
+CREATE TABLE IF NOT EXISTS crud (
     id VARCHAR(36) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description TEXT,


### PR DESCRIPTION
## Summary
- prevent the V1 CRUD schema migration from failing when the table already exists by making the CREATE TABLE idempotent

## Testing
- Not run (network required to download Maven Wrapper dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68e1611a8b44832983e2b9fb72b223fd