### PR TITLE
Publish CRUD creation events to Kafka

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>

--- a/application/src/main/java/com/xavelo/template/adapter/out/kafka/KafkaCrudEventPublisher.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/kafka/KafkaCrudEventPublisher.java
@@ -1,0 +1,41 @@
+package com.xavelo.template.adapter.out.kafka;
+
+import com.xavelo.template.application.port.out.CrudEventPublisher;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaCrudEventPublisher implements CrudEventPublisher {
+
+    private static final Logger logger = LogManager.getLogger(KafkaCrudEventPublisher.class);
+    private static final String TOPIC_NAME = "test-topic";
+
+    private final KafkaTemplate<String, CrudCreatedEvent> kafkaTemplate;
+
+    public KafkaCrudEventPublisher(KafkaTemplate<String, CrudCreatedEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @Override
+    public void publishCrudCreated(CrudCreatedEvent event) {
+        kafkaTemplate.send(TOPIC_NAME, event.id(), event)
+            .addCallback(
+                result -> {
+                    if (result != null && result.getRecordMetadata() != null) {
+                        logger.info(
+                            "Published CrudObject created event for id {} to topic {} partition {} offset {}",
+                            event.id(),
+                            result.getRecordMetadata().topic(),
+                            result.getRecordMetadata().partition(),
+                            result.getRecordMetadata().offset()
+                        );
+                    } else {
+                        logger.info("Published CrudObject created event for id {}", event.id());
+                    }
+                },
+                throwable -> logger.error("Failed to publish CrudObject created event for id {}", event.id(), throwable)
+            );
+    }
+}

--- a/application/src/main/java/com/xavelo/template/application/port/out/CrudEventPublisher.java
+++ b/application/src/main/java/com/xavelo/template/application/port/out/CrudEventPublisher.java
@@ -1,0 +1,34 @@
+package com.xavelo.template.application.port.out;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * Outbound port for publishing CrudObject domain events.
+ */
+public interface CrudEventPublisher {
+
+    /**
+     * Publishes an event indicating that a new CrudObject has been created.
+     *
+     * @param event payload describing the created CrudObject
+     */
+    void publishCrudCreated(CrudCreatedEvent event);
+
+    /**
+     * Event payload describing a created CrudObject.
+     */
+    record CrudCreatedEvent(String id, String name, String description, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+        public CrudCreatedEvent {
+            Objects.requireNonNull(id, "id must not be null");
+            Objects.requireNonNull(name, "name must not be null");
+            Objects.requireNonNull(createdAt, "createdAt must not be null");
+            Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+        }
+
+        public static CrudCreatedEvent fromRecord(CrudPort.CrudRecord record) {
+            Objects.requireNonNull(record, "record must not be null");
+            return new CrudCreatedEvent(record.id(), record.name(), record.description(), record.createdAt(), record.updatedAt());
+        }
+    }
+}

--- a/application/src/main/java/com/xavelo/template/application/service/CrudService.java
+++ b/application/src/main/java/com/xavelo/template/application/service/CrudService.java
@@ -5,6 +5,7 @@ import com.xavelo.template.api.contract.model.CrudObjectDto;
 import com.xavelo.template.api.contract.model.CrudObjectPageDto;
 import com.xavelo.template.application.exception.CrudObjectNotFoundException;
 import com.xavelo.template.application.port.in.CrudUseCase;
+import com.xavelo.template.application.port.out.CrudEventPublisher;
 import com.xavelo.template.application.port.out.CrudPort;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,9 +27,11 @@ public class CrudService implements CrudUseCase {
     private static final Logger logger = LogManager.getLogger(CrudService.class);
 
     private final CrudPort crudPort;
+    private final CrudEventPublisher crudEventPublisher;
 
-    public CrudService(CrudPort crudPort) {
+    public CrudService(CrudPort crudPort, CrudEventPublisher crudEventPublisher) {
         this.crudPort = crudPort;
+        this.crudEventPublisher = crudEventPublisher;
     }
 
     @Override
@@ -73,6 +76,7 @@ public class CrudService implements CrudUseCase {
         );
         CrudPort.CrudRecord stored = crudPort.save(toPersist);
         logger.info("Created CrudObject with id {}", stored.id());
+        crudEventPublisher.publishCrudCreated(CrudEventPublisher.CrudCreatedEvent.fromRecord(stored));
         return toDto(stored);
     }
 

--- a/application/src/main/java/com/xavelo/template/configuration/KafkaProducerConfig.java
+++ b/application/src/main/java/com/xavelo/template/configuration/KafkaProducerConfig.java
@@ -1,0 +1,39 @@
+package com.xavelo.template.configuration;
+
+import com.xavelo.template.application.port.out.CrudEventPublisher;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableConfigurationProperties(KafkaProducerProperties.class)
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, CrudEventPublisher.CrudCreatedEvent> crudCreatedEventProducerFactory(
+        KafkaProducerProperties properties
+    ) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, properties.getBootstrapServers());
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, CrudEventPublisher.CrudCreatedEvent> crudCreatedEventKafkaTemplate(
+        ProducerFactory<String, CrudEventPublisher.CrudCreatedEvent> crudCreatedEventProducerFactory
+    ) {
+        return new KafkaTemplate<>(crudCreatedEventProducerFactory);
+    }
+}

--- a/application/src/main/java/com/xavelo/template/configuration/KafkaProducerProperties.java
+++ b/application/src/main/java/com/xavelo/template/configuration/KafkaProducerProperties.java
@@ -1,0 +1,19 @@
+package com.xavelo.template.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Objects;
+
+@ConfigurationProperties(prefix = "kafka")
+public class KafkaProducerProperties {
+
+    private final String bootstrapServers;
+
+    public KafkaProducerProperties(String bootstrapServers) {
+        this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers must not be null");
+    }
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+}

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -24,3 +24,6 @@ management:
       exposure:
         include: "health,info,metrics"
 
+kafka:
+  bootstrap-servers: my-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+


### PR DESCRIPTION
## Summary
- add a Kafka outbound port and adapter that publishes CrudObject creation events to the test-topic
- configure a Kafka producer using bootstrap servers from application configuration and register the required template bean
- extend the CRUD service to emit events after persisting new records and include the spring-kafka dependency

## Testing
- `./mvnw -pl application test` *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e16fb47a2083298db0b72d8ab27f70