### PR TITLE
Migrate MySQL adapter to Spring Data JPA

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/application/src/main/java/com/xavelo/template/adapter/out/mysql/ItemEntity.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/mysql/ItemEntity.java
@@ -1,0 +1,96 @@
+package com.xavelo.template.adapter.out.mysql;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "item")
+public class ItemEntity {
+
+    protected ItemEntity() {
+        // Required by JPA
+    }
+
+    @Id
+    @Column(name = "id", nullable = false, length = 36)
+    private String id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @Column(name = "created_on", nullable = false)
+    private OffsetDateTime createdOn;
+
+    @Column(name = "modified_by")
+    private String modifiedBy;
+
+    @Column(name = "modified_on")
+    private OffsetDateTime modifiedOn;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public OffsetDateTime getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(OffsetDateTime createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public String getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+
+    public OffsetDateTime getModifiedOn() {
+        return modifiedOn;
+    }
+
+    public void setModifiedOn(OffsetDateTime modifiedOn) {
+        this.modifiedOn = modifiedOn;
+    }
+}
+

--- a/application/src/main/java/com/xavelo/template/adapter/out/mysql/ItemJpaRepository.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/mysql/ItemJpaRepository.java
@@ -1,0 +1,7 @@
+package com.xavelo.template.adapter.out.mysql;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemJpaRepository extends JpaRepository<ItemEntity, String> {
+}
+


### PR DESCRIPTION
## Summary
- replace the JDBC starter with Spring Data JPA in the application module
- introduce a JPA entity and repository for the item table
- refactor the MySQL adapter to delegate paging, lookups, and persistence to the JPA repository

## Testing
- `./mvnw -pl application test` *(fails: unable to download Maven wrapper due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23ca1190c8329b0fc26bea274f0e3