### PR TITLE
Add outbound Chuck Norris joke adapter

### DIFF
--- a/application/src/main/java/com/xavelo/template/adapter/out/joke/ChuckNorrisJokeClient.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/joke/ChuckNorrisJokeClient.java
@@ -1,0 +1,35 @@
+package com.xavelo.template.adapter.out.joke;
+
+import com.xavelo.template.configuration.ChuckNorrisProperties;
+import com.xavelo.template.joke.Joke;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class ChuckNorrisJokeClient implements JokeClient {
+
+    private final RestTemplate restTemplate;
+
+    public ChuckNorrisJokeClient(RestTemplateBuilder restTemplateBuilder, ChuckNorrisProperties properties) {
+        this.restTemplate = restTemplateBuilder
+                .rootUri(properties.getBaseUrl())
+                .build();
+    }
+
+    @Override
+    public Joke fetchRandomJoke() {
+        try {
+            ResponseEntity<ChuckNorrisJokeResponse> response = restTemplate.getForEntity("/jokes/random", ChuckNorrisJokeResponse.class);
+            ChuckNorrisJokeResponse body = response.getBody();
+            if (body == null) {
+                throw new RestClientException("Chuck Norris API returned an empty body");
+            }
+            return new Joke(body.id(), body.value(), body.url());
+        } catch (RestClientException e) {
+            throw new RestClientException("Failed to fetch joke from Chuck Norris API", e);
+        }
+    }
+}

--- a/application/src/main/java/com/xavelo/template/adapter/out/joke/ChuckNorrisJokeResponse.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/joke/ChuckNorrisJokeResponse.java
@@ -1,0 +1,12 @@
+package com.xavelo.template.adapter.out.joke;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChuckNorrisJokeResponse(
+        String id,
+        @JsonProperty("value") String value,
+        String url
+) {
+}

--- a/application/src/main/java/com/xavelo/template/adapter/out/joke/JokeClient.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/joke/JokeClient.java
@@ -1,0 +1,8 @@
+package com.xavelo.template.adapter.out.joke;
+
+import com.xavelo.template.joke.Joke;
+
+public interface JokeClient {
+
+    Joke fetchRandomJoke();
+}

--- a/application/src/main/java/com/xavelo/template/configuration/ChuckNorrisProperties.java
+++ b/application/src/main/java/com/xavelo/template/configuration/ChuckNorrisProperties.java
@@ -1,0 +1,22 @@
+package com.xavelo.template.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "chucknorris")
+public class ChuckNorrisProperties {
+
+    /**
+     * Base URL for the Chuck Norris jokes API.
+     */
+    private String baseUrl = "https://api.chucknorris.io";
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/application/src/main/java/com/xavelo/template/joke/Joke.java
+++ b/application/src/main/java/com/xavelo/template/joke/Joke.java
@@ -1,0 +1,4 @@
+package com.xavelo.template.joke;
+
+public record Joke(String id, String value, String url) {
+}

--- a/application/src/main/java/com/xavelo/template/joke/JokeController.java
+++ b/application/src/main/java/com/xavelo/template/joke/JokeController.java
@@ -1,0 +1,23 @@
+package com.xavelo.template.joke;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/jokes")
+public class JokeController {
+
+    private final JokeService jokeService;
+
+    public JokeController(JokeService jokeService) {
+        this.jokeService = jokeService;
+    }
+
+    @GetMapping("/random")
+    public ResponseEntity<Joke> randomJoke() {
+        Joke joke = jokeService.getRandomJoke();
+        return ResponseEntity.ok(joke);
+    }
+}

--- a/application/src/main/java/com/xavelo/template/joke/JokeService.java
+++ b/application/src/main/java/com/xavelo/template/joke/JokeService.java
@@ -1,0 +1,18 @@
+package com.xavelo.template.joke;
+
+import com.xavelo.template.adapter.out.joke.JokeClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JokeService {
+
+    private final JokeClient jokeClient;
+
+    public JokeService(JokeClient jokeClient) {
+        this.jokeClient = jokeClient;
+    }
+
+    public Joke getRandomJoke() {
+        return jokeClient.fetchRandomJoke();
+    }
+}

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -31,3 +31,6 @@ management:
       exposure:
         include: "health,info,metrics"
 
+chucknorris:
+  base-url: https://api.chucknorris.io
+

--- a/application/src/test/java/com/xavelo/template/adapter/out/joke/ChuckNorrisJokeClientTest.java
+++ b/application/src/test/java/com/xavelo/template/adapter/out/joke/ChuckNorrisJokeClientTest.java
@@ -1,0 +1,44 @@
+package com.xavelo.template.adapter.out.joke;
+
+import com.xavelo.template.configuration.ChuckNorrisProperties;
+import com.xavelo.template.joke.Joke;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RestClientTest(ChuckNorrisJokeClient.class)
+@TestPropertySource(properties = "chucknorris.base-url=https://api.chucknorris.io")
+@Import(ChuckNorrisProperties.class)
+class ChuckNorrisJokeClientTest {
+
+    @Autowired
+    private ChuckNorrisJokeClient jokeClient;
+
+    @Autowired
+    private MockRestServiceServer mockServer;
+
+    @Test
+    void fetchRandomJokeReturnsJoke() {
+        mockServer.expect(MockRestRequestMatchers.requestTo("/jokes/random"))
+                .andRespond(MockRestResponseCreators.withSuccess("""
+                        {
+                          \"id\": \"test-id\",
+                          \"value\": \"A hilarious joke\",
+                          \"url\": \"https://api.chucknorris.io/jokes/test-id\"
+                        }
+                        """, org.springframework.http.MediaType.APPLICATION_JSON));
+
+        Joke joke = jokeClient.fetchRandomJoke();
+
+        assertThat(joke.id()).isEqualTo("test-id");
+        assertThat(joke.value()).isEqualTo("A hilarious joke");
+        assertThat(joke.url()).isEqualTo("https://api.chucknorris.io/jokes/test-id");
+    }
+}

--- a/application/src/test/java/com/xavelo/template/joke/JokeControllerTest.java
+++ b/application/src/test/java/com/xavelo/template/joke/JokeControllerTest.java
@@ -1,0 +1,37 @@
+package com.xavelo.template.joke;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = JokeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class JokeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JokeService jokeService;
+
+    @Test
+    void randomJokeReturnsJoke() throws Exception {
+        given(jokeService.getRandomJoke())
+                .willReturn(new Joke("test-id", "A funny joke", "https://api.chucknorris.io/jokes/test-id"));
+
+        mockMvc.perform(get("/api/jokes/random").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("test-id"))
+                .andExpect(jsonPath("$.value").value("A funny joke"))
+                .andExpect(jsonPath("$.url").value("https://api.chucknorris.io/jokes/test-id"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Chuck Norris API configuration properties bean and RestTemplate-based client
- expose a random joke domain service and REST controller for testing the outbound adapter
- cover the client and controller with focused slice tests

## Testing
- mvn -am -pl application test

------
https://chatgpt.com/codex/tasks/task_e_68e23dd2d5f083299ec744d03a35bfed