### PR TITLE
Annotate joke adapters for metrics

### DIFF
--- a/application/src/main/java/com/xavelo/template/adapter/in/http/joke/JokeController.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/http/joke/JokeController.java
@@ -1,5 +1,8 @@
 package com.xavelo.template.adapter.in.http.joke;
 
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.template.application.domain.joke.Joke;
 import com.xavelo.template.application.port.in.joke.GetRandomJokeUseCase;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Adapter
 @RestController
 @RequestMapping("/api/jokes")
 public class JokeController {
@@ -18,6 +22,10 @@ public class JokeController {
     }
 
     @GetMapping("/random")
+    @CountAdapterInvocation(
+            name = "joke-random",
+            direction = AdapterMetrics.Direction.IN,
+            type = AdapterMetrics.Type.HTTP)
     public ResponseEntity<Joke> randomJoke() {
         Joke joke = getRandomJokeUseCase.getRandomJoke();
         return ResponseEntity.ok(joke);

--- a/application/src/main/java/com/xavelo/template/adapter/out/http/joke/ChuckNorrisJokeAdapter.java
+++ b/application/src/main/java/com/xavelo/template/adapter/out/http/joke/ChuckNorrisJokeAdapter.java
@@ -1,15 +1,17 @@
 package com.xavelo.template.adapter.out.http.joke;
 
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.template.application.domain.joke.Joke;
 import com.xavelo.template.application.port.out.joke.GetRandomJokePort;
 import com.xavelo.template.configuration.ChuckNorrisProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-@Component
+@Adapter
 public class ChuckNorrisJokeAdapter implements GetRandomJokePort {
 
     private final RestTemplate restTemplate;
@@ -21,6 +23,10 @@ public class ChuckNorrisJokeAdapter implements GetRandomJokePort {
     }
 
     @Override
+    @CountAdapterInvocation(
+            name = "chuck-norris-random",
+            direction = AdapterMetrics.Direction.OUT,
+            type = AdapterMetrics.Type.HTTP)
     public Joke getRandomJoke() {
         try {
             ResponseEntity<ChuckNorrisJokeResponse> response = restTemplate.getForEntity("/jokes/random", ChuckNorrisJokeResponse.class);


### PR DESCRIPTION
## Summary
- apply the shared @Adapter stereotype to the joke HTTP controller and outbound client
- add CountAdapterInvocation metrics to track inbound and outbound joke requests

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e245da83a48329b66680d0d6c68e24