### PR TITLE
Realign Kafka consumer configuration prefix

### DIFF
--- a/application/src/main/java/com/xavelo/template/adapter/in/kafka/EventConsumer.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/kafka/EventConsumer.java
@@ -6,11 +6,9 @@ import com.xavelo.common.metrics.Adapter;
 import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.template.application.domain.Event;
 import com.xavelo.template.application.port.in.ProcessEventUseCase;
-import com.xavelo.template.configuration.EventConsumerProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
@@ -31,10 +29,10 @@ public class EventConsumer {
     }
 
     @KafkaListener(
-        topics = "test-topic",
+        topics = "${kafka.consumer.topic}",
         containerFactory = "testTopicEventKafkaListenerContainerFactory"
     )
-    @CountAdapterInvocation(name = "test-topic-event", direction = IN, type = KAFKA)
+    @CountAdapterInvocation(name = "item-events", direction = IN, type = KAFKA)
     public void consume(String payload) {
         try {
             Event event = objectMapper.readValue(payload, Event.class);

--- a/application/src/main/java/com/xavelo/template/configuration/EventConsumerProperties.java
+++ b/application/src/main/java/com/xavelo/template/configuration/EventConsumerProperties.java
@@ -2,10 +2,10 @@ package com.xavelo.template.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "kafka-event-consumer")
+@ConfigurationProperties(prefix = "kafka.consumer")
 public class EventConsumerProperties {
 
-    private String topic = "test-topic";
+    private String topic;
     private String groupId = "template-app-test-topic-consumer";
     private int concurrency = 1;
     private long errorBackoffIntervalMs = 1000L;

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -24,7 +24,6 @@ spring:
   kafka:
     bootstrap-servers: my-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
 
-
 management:
   endpoints:
     web:
@@ -34,4 +33,10 @@ management:
 chucknorris:
   base-url: https://api.chucknorris.io
 
-
+kafka:
+  consumer:
+    topic: test-topic
+    group-id: template-app-test-topic-consumer
+    concurrency: 1
+    error-backoff-interval-ms: 1000
+    error-max-retries: 3


### PR DESCRIPTION
## Summary
- move the Kafka inbound consumer properties under the shared `kafka.consumer` prefix
- update the consumer properties bean and listener to resolve the topic from the new location

## Testing
- mvnw -pl application test *(fails: network is unreachable while downloading Maven Wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b015724483298ed1a907babf9184