### PR TITLE
Rename async API and keep ping endpoints synchronous

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -154,6 +154,39 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>generate-async-openapi-contract</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/async-api.yaml</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateModelTests>false</generateModelTests>
+                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <additionalProperties>
+                                <additionalProperty>apiPackage=com.xavelo.template.api.contract.api</additionalProperty>
+                                <additionalProperty>basePackage=com.xavelo.template.api.contract</additionalProperty>
+                                <additionalProperty>modelPackage=com.xavelo.template.api.contract.model</additionalProperty>
+                                <additionalProperty>dateLibrary=java8</additionalProperty>
+                                <additionalProperty>modelNameSuffix=Dto</additionalProperty>
+                                <additionalProperty>useJakartaEe=true</additionalProperty>
+                                <additionalProperty>serializationLibrary=jackson</additionalProperty>
+                                <additionalProperty>useTags=true</additionalProperty>
+                                <additionalProperty>useSpringBoot3=true</additionalProperty>
+                                <additionalProperty>async=true</additionalProperty>
+                            </additionalProperties>
+                            <configOptions>
+                                <sourceFolder>src/main/java</sourceFolder>
+                                <interfaceOnly>true</interfaceOnly>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/api/src/main/resources/openapi/async-api.yaml
+++ b/api/src/main/resources/openapi/async-api.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Async API
+  version: 1.0.0
+  description: API definition for triggering an asynchronous operation.
+servers:
+  - url: /
+paths:
+  /api/async-operation:
+    get:
+      tags:
+        - Async
+      operationId: triggerAsyncOperation
+      summary: Executes an asynchronous operation and returns its result.
+      responses:
+        '200':
+          description: Async operation completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncOperationResponse'
+components:
+  schemas:
+    AsyncOperationResponse:
+      type: object
+      required:
+        - message
+        - durationMs
+      properties:
+        message:
+          type: string
+          description: Human-readable summary of the operation outcome.
+        durationMs:
+          type: integer
+          format: int64
+          description: Duration of the operation in milliseconds.

--- a/application/src/main/java/com/xavelo/template/adapter/in/http/asyncoperation/AsyncOperationController.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/http/asyncoperation/AsyncOperationController.java
@@ -1,0 +1,46 @@
+package com.xavelo.template.adapter.in.http.asyncoperation;
+
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.AdapterMetrics;
+import com.xavelo.common.metrics.CountAdapterInvocation;
+import com.xavelo.template.api.contract.api.AsyncApi;
+import com.xavelo.template.api.contract.model.AsyncOperationResponseDto;
+import com.xavelo.template.application.domain.AsyncOperationResult;
+import com.xavelo.template.application.port.in.asyncoperation.AsyncOperationUseCase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.CompletableFuture;
+
+@Adapter
+@RestController
+public class AsyncOperationController implements AsyncApi {
+
+    private static final Logger logger = LogManager.getLogger(AsyncOperationController.class);
+
+    private final AsyncOperationUseCase asyncOperationUseCase;
+
+    public AsyncOperationController(AsyncOperationUseCase asyncOperationUseCase) {
+        this.asyncOperationUseCase = asyncOperationUseCase;
+    }
+
+    @Override
+    @CountAdapterInvocation(
+            name = "async-operation",
+            direction = AdapterMetrics.Direction.IN,
+            type = AdapterMetrics.Type.HTTP)
+    public CompletableFuture<ResponseEntity<AsyncOperationResponseDto>> triggerAsyncOperation() {
+        return asyncOperationUseCase.triggerAsyncOperationAsync()
+                .thenApply(this::mapToResponse);
+    }
+
+    private ResponseEntity<AsyncOperationResponseDto> mapToResponse(AsyncOperationResult result) {
+        logger.info("Returning result for async operation in {} ms", result.durationMs());
+        AsyncOperationResponseDto responseDto = new AsyncOperationResponseDto()
+                .message(result.message())
+                .durationMs(result.durationMs());
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/application/src/main/java/com/xavelo/template/adapter/in/http/item/ItemController.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/http/item/ItemController.java
@@ -56,6 +56,4 @@ public class ItemController implements ItemApi {
         return ResponseEntity.ok(item);
     }
 
-
-
 }

--- a/application/src/main/java/com/xavelo/template/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/http/secure/SecurePingController.java
@@ -19,7 +19,7 @@ public class SecurePingController implements SecurePingApi {
 
     @Value("${HOSTNAME:unknown}")
     private String podName;
-    
+
     @CountAdapterInvocation(
         name = "secure-ping",
         direction = AdapterMetrics.Direction.IN,

--- a/application/src/main/java/com/xavelo/template/application/domain/AsyncOperationResult.java
+++ b/application/src/main/java/com/xavelo/template/application/domain/AsyncOperationResult.java
@@ -1,0 +1,4 @@
+package com.xavelo.template.application.domain;
+
+public record AsyncOperationResult(String message, long durationMs) {
+}

--- a/application/src/main/java/com/xavelo/template/application/port/in/asyncoperation/AsyncOperationUseCase.java
+++ b/application/src/main/java/com/xavelo/template/application/port/in/asyncoperation/AsyncOperationUseCase.java
@@ -1,0 +1,17 @@
+package com.xavelo.template.application.port.in.asyncoperation;
+
+import com.xavelo.template.application.domain.AsyncOperationResult;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Application port exposing the ability to trigger an asynchronous operation.
+ */
+public interface AsyncOperationUseCase {
+
+    default AsyncOperationResult triggerAsyncOperation() {
+        return triggerAsyncOperationAsync().join();
+    }
+
+    CompletableFuture<AsyncOperationResult> triggerAsyncOperationAsync();
+}

--- a/application/src/main/java/com/xavelo/template/application/service/AsyncOperationService.java
+++ b/application/src/main/java/com/xavelo/template/application/service/AsyncOperationService.java
@@ -1,0 +1,36 @@
+package com.xavelo.template.application.service;
+
+import com.xavelo.template.application.domain.AsyncOperationResult;
+import com.xavelo.template.application.port.in.asyncoperation.AsyncOperationUseCase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class AsyncOperationService implements AsyncOperationUseCase {
+
+    private static final Logger logger = LogManager.getLogger(AsyncOperationService.class);
+
+    private static final long SIMULATED_WORK_DURATION_MS = 750L;
+
+    @Override
+    @Async("applicationTaskExecutor")
+    public CompletableFuture<AsyncOperationResult> triggerAsyncOperationAsync() {
+        Instant start = Instant.now();
+        try {
+            Thread.sleep(SIMULATED_WORK_DURATION_MS);
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Async operation was interrupted", interruptedException);
+        }
+        long duration = Duration.between(start, Instant.now()).toMillis();
+        AsyncOperationResult result = new AsyncOperationResult("Async operation completed", duration);
+        logger.info("Async operation completed in {} ms", duration);
+        return CompletableFuture.completedFuture(result);
+    }
+}

--- a/application/src/main/java/com/xavelo/template/configuration/AsyncConfig.java
+++ b/application/src/main/java/com/xavelo/template/configuration/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.xavelo.template.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "applicationTaskExecutor")
+    public Executor applicationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("application-async-");
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(100);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/application/src/test/java/com/xavelo/template/adapter/in/http/asyncoperation/AsyncOperationControllerAsyncTest.java
+++ b/application/src/test/java/com/xavelo/template/adapter/in/http/asyncoperation/AsyncOperationControllerAsyncTest.java
@@ -1,0 +1,47 @@
+package com.xavelo.template.adapter.in.http.asyncoperation;
+
+import com.xavelo.template.application.domain.AsyncOperationResult;
+import com.xavelo.template.application.port.in.asyncoperation.AsyncOperationUseCase;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AsyncOperationController.class)
+class AsyncOperationControllerAsyncTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AsyncOperationUseCase asyncOperationUseCase;
+
+    @Test
+    void triggerAsyncOperationReturnsAsyncResponse() throws Exception {
+        AsyncOperationResult result = new AsyncOperationResult("Async operation completed", 750L);
+        Mockito.when(asyncOperationUseCase.triggerAsyncOperationAsync())
+                .thenReturn(CompletableFuture.completedFuture(result));
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/async-operation"))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Async operation completed"))
+                .andExpect(jsonPath("$.durationMs").value(750));
+    }
+}


### PR DESCRIPTION
## Summary
- rename the expensive operation OpenAPI contract to an async API with the `/api/async-operation` endpoint and update generator configuration
- refactor the async controller, domain, port, and service classes to AsyncOperation naming while preserving asynchronous execution
- return the ping and secure ping controllers to synchronous ResponseEntity handlers so only the async API uses CompletableFuture

## Testing
- mvn -pl application -am test

------
https://chatgpt.com/codex/tasks/task_e_68e2756a9f048329b79c5c7ee79d7098