### PR TITLE
Switch Kafka listener to ConsumerRecord signature

### DIFF
--- a/application/src/main/java/com/xavelo/template/adapter/in/kafka/EventConsumer.java
+++ b/application/src/main/java/com/xavelo/template/adapter/in/kafka/EventConsumer.java
@@ -8,7 +8,9 @@ import com.xavelo.template.application.domain.Event;
 import com.xavelo.template.application.port.in.ProcessEventUseCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
@@ -33,10 +35,13 @@ public class EventConsumer {
         containerFactory = "testTopicEventKafkaListenerContainerFactory"
     )
     @CountAdapterInvocation(name = "item-events", direction = IN, type = KAFKA)
-    public void consume(String payload) {
+    public void consume(ConsumerRecord<String, String> record, Acknowledgment acknowledgment) {
         try {
-            Event event = objectMapper.readValue(payload, Event.class);
+            Event event = objectMapper.readValue(record.value(), Event.class);
             processEventUseCase.process(event);
+            if (acknowledgment != null) {
+                acknowledgment.acknowledge();
+            }
         } catch (JsonProcessingException e) {
             logger.error("Unable to deserialize event payload", e);
             throw new IllegalStateException("Failed to deserialize event", e);

--- a/application/src/test/java/com/xavelo/template/adapter/in/kafka/ItemEventConsumerTest.java
+++ b/application/src/test/java/com/xavelo/template/adapter/in/kafka/ItemEventConsumerTest.java
@@ -3,6 +3,7 @@ package com.xavelo.template.adapter.in.kafka;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xavelo.template.application.domain.Event;
 import com.xavelo.template.application.port.in.ProcessEventUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,8 +29,9 @@ class ItemEventConsumerTest {
     void shouldInvokeInboundPortWhenPayloadIsConsumed() throws Exception {
         Event event = new Event("event-id", "Test event");
         String payload = objectMapper.writeValueAsString(event);
+        ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("topic", 0, 0L, "key", payload);
 
-        itemEventConsumer.consume(payload);
+        itemEventConsumer.consume(consumerRecord, null);
 
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
         verify(processEventUseCase).process(eventCaptor.capture());


### PR DESCRIPTION
## Summary
- update the Kafka listener to receive the full ConsumerRecord and optional acknowledgment handle
- adjust the unit test to build a ConsumerRecord for invoking the listener

## Testing
- `./mvnw -pl application test` *(fails: Network is unreachable while downloading Maven Wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b8b703b883298a3851d505eacafc